### PR TITLE
feat(commit): restrict /commit command to threads 

### DIFF
--- a/interaction-handlers.go
+++ b/interaction-handlers.go
@@ -178,35 +178,32 @@ func handleOpencodeCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 }
 
 // constructPRLink parses the remote URL and constructs a PR link for the given branch
-func constructPRLink(remoteURL, branch string) string {
+func constructRepoLink(remoteURL string) string {
 	// Remove .git suffix if present
 	remoteURL = strings.TrimSuffix(remoteURL, ".git")
 
-	// Handle different URL formats
-	var repoPath string
-	if strings.HasPrefix(remoteURL, "https://") {
-		// HTTPS format: https://github.com/user/repo
+	// Convert SSH format to HTTPS format
+	if strings.HasPrefix(remoteURL, "git@") {
+		// SSH format: git@github.com:user/repo -> https://github.com/user/repo
 		if strings.Contains(remoteURL, "github.com") {
-			repoPath = strings.TrimPrefix(remoteURL, "https://github.com/")
-			return fmt.Sprintf("https://github.com/%s/compare/%s?expand=1", repoPath, branch)
-		} else if strings.Contains(remoteURL, "gitlab.com") {
-			repoPath = strings.TrimPrefix(remoteURL, "https://gitlab.com/")
-			return fmt.Sprintf("https://gitlab.com/%s/-/merge_requests/new?merge_request[source_branch]=%s", repoPath, branch)
-		}
-	} else if strings.HasPrefix(remoteURL, "git@") {
-		// SSH format: git@github.com:user/repo.git
-		if strings.Contains(remoteURL, "github.com") {
-			repoPath = strings.TrimPrefix(remoteURL, "git@github.com:")
+			repoPath := strings.TrimPrefix(remoteURL, "git@github.com:")
 			repoPath = strings.Replace(repoPath, ":", "/", 1)
-			return fmt.Sprintf("https://github.com/%s/compare/%s?expand=1", repoPath, branch)
+			return fmt.Sprintf("https://github.com/%s", repoPath)
 		} else if strings.Contains(remoteURL, "gitlab.com") {
-			repoPath = strings.TrimPrefix(remoteURL, "git@gitlab.com:")
+			repoPath := strings.TrimPrefix(remoteURL, "git@gitlab.com:")
 			repoPath = strings.Replace(repoPath, ":", "/", 1)
-			return fmt.Sprintf("https://gitlab.com/%s/-/merge_requests/new?merge_request[source_branch]=%s", repoPath, branch)
+			return fmt.Sprintf("https://gitlab.com/%s", repoPath)
+		} else if strings.Contains(remoteURL, "bitbucket.org") {
+			repoPath := strings.TrimPrefix(remoteURL, "git@bitbucket.org:")
+			repoPath = strings.Replace(repoPath, ":", "/", 1)
+			return fmt.Sprintf("https://bitbucket.org/%s", repoPath)
 		}
+	} else if strings.HasPrefix(remoteURL, "https://") {
+		// Already HTTPS format, return as-is
+		return remoteURL
 	}
 
-	// If we can't determine the hosting service, return empty string
+	// If we can't parse the URL, return empty string
 	return ""
 }
 
@@ -485,18 +482,18 @@ func handleCommitCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		slog.Debug("saved session data with success status", "thread_id", threadID, "commit_hash", commitHash)
 	}
 
-	// Get PR/MR link if available
-	var prLink string
+	// Get repository link if available
+	var repoLink string
 	remoteCmd := exec.Command("git", "remote", "get-url", "origin")
 	remoteCmd.Dir = worktreePath
 	if remoteOutput, err := remoteCmd.CombinedOutput(); err == nil {
 		remoteURL := strings.TrimSpace(string(remoteOutput))
 		slog.Debug("got remote URL", "thread_id", threadID, "remote_url", remoteURL)
 
-		// Parse remote URL to extract repository info and construct PR link
-		if prURL := constructPRLink(remoteURL, currentBranch); prURL != "" {
-			prLink = prURL
-			slog.Debug("constructed PR link", "thread_id", threadID, "pr_link", prLink)
+		// Parse remote URL to extract repository link
+		if repoURL := constructRepoLink(remoteURL); repoURL != "" {
+			repoLink = repoURL
+			slog.Debug("extracted repository link", "thread_id", threadID, "repo_link", repoLink)
 		}
 	} else {
 		slog.Debug("failed to get remote URL", "thread_id", threadID, "error", err)
@@ -509,8 +506,8 @@ func handleCommitCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	detailedMessage := fmt.Sprintf("**Commit & Push Successful**\n\n**Summary:** %s\n**Hash:** %s\n**Branch:** %s",
 		summary, commitHash, currentBranch)
 
-	if prLink != "" {
-		detailedMessage += fmt.Sprintf("\n\n**Pull Request:** %s", prLink)
+	if repoLink != "" {
+		detailedMessage += fmt.Sprintf("\n\n**Repository:** %s", repoLink)
 	}
 
 	detailedMessage += fmt.Sprintf("\n\n**Git Push Output:**\n```\n%s\n```", strings.TrimSpace(string(pushOutput)))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Success messages now include a repository/PR link when a remote URL can be resolved (supports common hosts) and will fall back to any HTTPS URL if no PR link is found.
* **Bug Fixes**
  * Commit command only works inside code-session threads; users receive a private (ephemeral) guidance message if invoked elsewhere or if channel info can’t be retrieved.
  * Non-thread invocations are blocked earlier to prevent unintended session or git actions.
* **Improvements**
  * Success message layout clarified (Summary, Hash, Branch first; Repository/PR line appended when available) and logging enhanced with thread context and PR-link extraction details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->