### PR TITLE
refactor(bot): rename opencode command to codesession

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,16 @@ This is a Discord bot that integrates with OpenCode, allowing users to start AI 
 - **Main Components**:
   - `main.go`: Entry point that runs both Discord bot and OpenCode server concurrently
   - `discord.go`: Discord bot setup, slash command registration, and message handling
-  - `interaction-handlers.go`: Discord slash command handlers (`/ping`, `/opencode`, `/commit`)
+  - `interaction-handlers.go`: Discord slash command handlers (`/ping`, `/codesession`, `/commit`)
   - `opencode-server.go`: OpenCode server management and lifecycle
   - `opencode-client.go`: OpenCode client integration, session management, and event streaming
   - `opencode-event-types.go`: Type definitions for OpenCode event handling
   - `config.go`: TOML configuration loading and management
 
 - **Core Features**:
-  - Discord slash commands for starting OpenCode sessions
+  - Discord slash commands for starting CodeSession sessions
   - Git worktree creation for isolated development environments
-  - Real-time OpenCode event streaming to Discord threads
+  - Real-time CodeSession event streaming to Discord threads
   - Automatic commit generation with AI summaries
   - Session persistence and recovery
 
@@ -52,7 +52,7 @@ name = "repository_name"
 
 - Sessions are stored in `.sessions/` directory as JSON files
 - Worktrees are created in `.worktrees/` directory
-- Each Discord thread corresponds to one OpenCode session
+  - Each Discord thread corresponds to one CodeSession session
 - Sessions persist across bot restarts and can be lazy-loaded
 
 ## Key Dependencies

--- a/discord.go
+++ b/discord.go
@@ -102,8 +102,8 @@ func registerCommands(s *discordgo.Session) error {
 			Description: "Show diff of changes in current worktree",
 		},
 		{
-			Name:        "opencode",
-			Description: "Starting work with Opencode",
+			Name:        "codesession",
+			Description: "Starting work with CodeSession",
 			Type:        discordgo.ChatApplicationCommand,
 			Options: []*discordgo.ApplicationCommandOption{
 				{

--- a/git-ops.go
+++ b/git-ops.go
@@ -284,8 +284,8 @@ func (g *GitOperations) Commit(worktreePath, message string) (string, error) {
 	// Create commit
 	commit, err := worktree.Commit(message, &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  "OpenCode Bot",
-			Email: "opencode-bot@example.com",
+			Name:  "CodeSession Bot",
+			Email: "codesession-bot@example.com",
 		},
 	})
 	if err != nil {

--- a/interaction-handlers.go
+++ b/interaction-handlers.go
@@ -29,7 +29,7 @@ func InteractionHandlers(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		})
 	}
 
-	if command == "opencode" {
+	if command == "codesession" {
 		handleOpencodeCommand(s, i)
 	}
 
@@ -84,7 +84,7 @@ func handleOpencodeCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	slog.Debug("creating thread", "thread_name", threadName, "channel_id", i.ChannelID)
 	thread, err := s.ThreadStart(
 		i.ChannelID,
-		fmt.Sprintf("OpenCode: %s", threadName),
+		fmt.Sprintf("CodeSession: %s", threadName),
 		discordgo.ChannelTypeGuildPublicThread,
 		1440, // 24 hours
 	)
@@ -161,7 +161,7 @@ func handleOpencodeCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	slog.Debug("sending welcome message to thread", "thread_id", thread.ID)
 	trimmedWorktreeDir := strings.TrimPrefix(worktreeDir, repository.Path)
 	welcomeMessage := fmt.Sprintf(`%s
-OpenCode Session Started
+CodeSession Session Started
 Repository: %s
 Model: %s
 Worktree Path: %s
@@ -173,7 +173,7 @@ Session ID: %s
 	// Update the interaction response with success message AFTER welcome message
 	slog.Debug("updating interaction response", "thread_id", thread.ID)
 	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: &[]string{fmt.Sprintf("OpenCode session created successfully! Check the thread: %s", thread.Mention())}[0],
+		Content: &[]string{fmt.Sprintf("CodeSession session created successfully! Check the thread: %s", thread.Mention())}[0],
 	})
 }
 
@@ -197,7 +197,7 @@ func handleCommitCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if session == nil {
 		slog.Error("no session found for thread", "thread_id", threadID)
 		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: &[]string{"No OpenCode session found for this thread. Please start a session first using `/opencode` command."}[0],
+			Content: &[]string{"No CodeSession session found for this thread. Please start a session first using `/codesession` command."}[0],
 		})
 		return
 	}
@@ -463,7 +463,7 @@ func MessageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	slog.Debug("lazy loading session", "thread_id", threadID)
 	sessionData := lazyLoadSession(threadID)
 	if sessionData == nil {
-		s.ChannelMessageSend(m.ChannelID, "No OpenCode session found for this thread. Please start a session first using `/opencode` command.")
+		s.ChannelMessageSend(m.ChannelID, "No CodeSession session found for this thread. Please start a session first using `/codesession` command.")
 		return
 	}
 
@@ -481,7 +481,7 @@ func MessageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	content = strings.TrimSpace(content)
 
 	if content == "" {
-		s.ChannelMessageSend(m.ChannelID, "Please provide a message to send to OpenCode.")
+		s.ChannelMessageSend(m.ChannelID, "Please provide a message to send to CodeSession.")
 		return
 	}
 
@@ -491,7 +491,7 @@ func MessageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// send message to opencode
 	response := SendMessage(threadID, content)
 	if response == nil {
-		s.ChannelMessageSend(m.ChannelID, "Failed to send message to OpenCode.")
+		s.ChannelMessageSend(m.ChannelID, "Failed to send message to CodeSession.")
 		return
 	}
 }
@@ -516,7 +516,7 @@ func handleDiffCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if session == nil {
 		slog.Error("no session found for thread", "thread_id", threadID)
 		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: &[]string{"No OpenCode session found for this thread. Please start a session first using `/opencode` command."}[0],
+			Content: &[]string{"No CodeSession session found for this thread. Please start a session first using `/codesession` command."}[0],
 		})
 		return
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Rebranded OpenCode to CodeSession across the app.
  - Renamed slash command from /opencode to /codesession with updated descriptions.
  - Updated all user-facing messages and thread titles to reference CodeSession.
  - Git commits now show “CodeSession Bot” as the author.
- Documentation
  - Updated documentation to reflect CodeSession branding, including terminology for sessions and event streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->