### PR TITLE
refactor(discord): Update Discord references from OpenCode to CodeSession

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,22 @@
 ## CodeSession - Agent Guidelines
 
-This is a Discord bot that integrates with OpenCode, allowing users to start AI coding sessions through Discord. The bot creates git worktrees for isolated development environments and manages OpenCode sessions for collaborative coding.
+This is a Discord bot that integrates with CodeSession, allowing users to start AI coding sessions through Discord. The bot creates git worktrees for isolated development environments and manages CodeSession sessions for collaborative coding.
 
 ## Architecture
 
 - **Main Components**:
   - `main.go`: Entry point that runs both Discord bot and OpenCode server concurrently
   - `discord.go`: Discord bot setup, slash command registration, and message handling
-  - `interaction-handlers.go`: Discord slash command handlers (`/ping`, `/opencode`, `/commit`)
+  - `interaction-handlers.go`: Discord slash command handlers (`/ping`, `/codesession`, `/commit`)
   - `opencode-server.go`: OpenCode server management and lifecycle
   - `opencode-client.go`: OpenCode client integration, session management, and event streaming
   - `opencode-event-types.go`: Type definitions for OpenCode event handling
   - `config.go`: TOML configuration loading and management
 
 - **Core Features**:
-  - Discord slash commands for starting OpenCode sessions
+  - Discord slash commands for starting CodeSession sessions
   - Git worktree creation for isolated development environments
-  - Real-time OpenCode event streaming to Discord threads
+  - Real-time CodeSession event streaming to Discord threads
   - Automatic commit generation with AI summaries
   - Session persistence and recovery
 
@@ -52,7 +52,7 @@ name = "repository_name"
 
 - Sessions are stored in `.sessions/` directory as JSON files
 - Worktrees are created in `.worktrees/` directory
-- Each Discord thread corresponds to one OpenCode session
+  - Each Discord thread corresponds to one CodeSession session
 - Sessions persist across bot restarts and can be lazy-loaded
 
 ## Key Dependencies

--- a/discord.go
+++ b/discord.go
@@ -103,7 +103,7 @@ func registerCommands(s *discordgo.Session) error {
 		},
 		{
 			Name:        "opencode",
-			Description: "Starting work with Opencode",
+			Description: "Starting work with CodeSession",
 			Type:        discordgo.ChatApplicationCommand,
 			Options: []*discordgo.ApplicationCommandOption{
 				{

--- a/interaction-handlers.go
+++ b/interaction-handlers.go
@@ -84,7 +84,7 @@ func handleOpencodeCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	slog.Debug("creating thread", "thread_name", threadName, "channel_id", i.ChannelID)
 	thread, err := s.ThreadStart(
 		i.ChannelID,
-		fmt.Sprintf("OpenCode: %s", threadName),
+		fmt.Sprintf("CodeSession: %s", threadName),
 		discordgo.ChannelTypeGuildPublicThread,
 		1440, // 24 hours
 	)
@@ -161,7 +161,7 @@ func handleOpencodeCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	slog.Debug("sending welcome message to thread", "thread_id", thread.ID)
 	trimmedWorktreeDir := strings.TrimPrefix(worktreeDir, repository.Path)
 	welcomeMessage := fmt.Sprintf(`%s
-OpenCode Session Started
+CodeSession Session Started
 Repository: %s
 Model: %s
 Worktree Path: %s
@@ -173,7 +173,7 @@ Session ID: %s
 	// Update the interaction response with success message AFTER welcome message
 	slog.Debug("updating interaction response", "thread_id", thread.ID)
 	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: &[]string{fmt.Sprintf("OpenCode session created successfully! Check the thread: %s", thread.Mention())}[0],
+		Content: &[]string{fmt.Sprintf("CodeSession session created successfully! Check the thread: %s", thread.Mention())}[0],
 	})
 }
 
@@ -197,7 +197,7 @@ func handleCommitCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if session == nil {
 		slog.Error("no session found for thread", "thread_id", threadID)
 		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: &[]string{"No OpenCode session found for this thread. Please start a session first using `/opencode` command."}[0],
+			Content: &[]string{"No CodeSession session found for this thread. Please start a session first using `/opencode` command."}[0],
 		})
 		return
 	}
@@ -459,7 +459,7 @@ func MessageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	slog.Debug("lazy loading session", "thread_id", threadID)
 	sessionData := lazyLoadSession(threadID)
 	if sessionData == nil {
-		s.ChannelMessageSend(m.ChannelID, "No OpenCode session found for this thread. Please start a session first using `/opencode` command.")
+		s.ChannelMessageSend(m.ChannelID, "No CodeSession session found for this thread. Please start a session first using `/opencode` command.")
 		return
 	}
 
@@ -477,7 +477,7 @@ func MessageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	content = strings.TrimSpace(content)
 
 	if content == "" {
-		s.ChannelMessageSend(m.ChannelID, "Please provide a message to send to OpenCode.")
+		s.ChannelMessageSend(m.ChannelID, "Please provide a message to send to CodeSession.")
 		return
 	}
 
@@ -487,7 +487,7 @@ func MessageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// send message to opencode
 	response := SendMessage(threadID, content)
 	if response == nil {
-		s.ChannelMessageSend(m.ChannelID, "Failed to send message to OpenCode.")
+		s.ChannelMessageSend(m.ChannelID, "Failed to send message to CodeSession.")
 		return
 	}
 }
@@ -512,7 +512,7 @@ func handleDiffCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if session == nil {
 		slog.Error("no session found for thread", "thread_id", threadID)
 		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: &[]string{"No OpenCode session found for this thread. Please start a session first using `/opencode` command."}[0],
+			Content: &[]string{"No CodeSession session found for this thread. Please start a session first using `/opencode` command."}[0],
 		})
 		return
 	}


### PR DESCRIPTION
- Changed thread names from "OpenCode:" to "CodeSession:" in interaction handlers
- Updated welcome and success messages to use "CodeSession" instead of "OpenCode"
- Modified error messages and user prompts to reference "CodeSession"
- Updated slash command description in discord.go
- Revised AGENTS.md documentation to reflect CodeSession branding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Rebranded OpenCode to CodeSession across the app’s user-facing text.
  - Renamed the slash command to /codesession; updated thread names, welcome, status, and error messages accordingly.

- Documentation
  - Updated docs to reflect CodeSession branding, including core features, event streaming, and session mapping.
  - Minor formatting cleanup (removed a redundant header and adjusted bullet indentation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->